### PR TITLE
DEVOPS-5836: Adds .claude/settings.local.json and mcp-vscode.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,3 @@ sam-template-output.yaml
 node_modules/
 mcp-vscode.json
 .claude/settings.local.json
-.claude/settings.local.json
-mcp-vscode.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 sam-template-output.yaml
 node_modules/
+mcp-vscode.json
+.claude/settings.local.json

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ sam-template-output.yaml
 node_modules/
 mcp-vscode.json
 .claude/settings.local.json
+.claude/settings.local.json
+mcp-vscode.json


### PR DESCRIPTION
## Summary
Adds `.claude/settings.local.json` and `mcp-vscode.json` to `.gitignore`.

`.claude/settings.local.json` is the user-specific local override file for Claude Code and should not be committed. We are intentionally not ignoring the entire `.claude/` directory as shared project config may exist there.

`mcp-vscode.json` is the VS Code MCP configuration file that should not be committed.

Fixes DEVOPS-5836